### PR TITLE
Clubs and Users Connection

### DIFF
--- a/ProjectSourceCode/src/init_data/00_create.sql
+++ b/ProjectSourceCode/src/init_data/00_create.sql
@@ -10,7 +10,6 @@ CREATE TABLE users (
 CREATE TABLE clubs (
     clubID serial NOT NULL,
     clubName varchar(60) NOT NULL,
-    clubDescription text NOT NULL,
     organizer int NOT NULL,
     PRIMARY KEY (ClubID),
     CONSTRAINT FK_OrganizerUserID FOREIGN KEY (organizer) REFERENCES users (userID)

--- a/ProjectSourceCode/src/init_data/01_insert.sql
+++ b/ProjectSourceCode/src/init_data/01_insert.sql
@@ -1,15 +1,15 @@
 INSERT INTO users (userName, userPassword, userAdmin)
 VALUES --DO NOT USE THESE TO LOG IN. PASSWORD IS NOT ENCODED--
-('DevOrg1', '123', True),
-('DevOrg2', '123', True),
+('Default Organizer 1', '123', True),
+('Default Organizer 2', '123', True),
 ('DevUser1', '123', False),
 ('DevUser2', '123', False),
 ('DevUser3', '123', False);
 
-INSERT INTO clubs (clubName, clubDescription, organizer)
+INSERT INTO clubs (clubName, organizer)
 VALUES 
-('Club1', 'This is sample club 1.', 1),
-('Club2', 'This is sample club 2.', 2);
+('Club1', 1),
+('Club2', 1);
 
 INSERT INTO locations (buildingName, latitude, longitude)
 VALUES

--- a/ProjectSourceCode/src/views/pages/register.hbs
+++ b/ProjectSourceCode/src/views/pages/register.hbs
@@ -5,13 +5,35 @@
         <div class= "mb-3">
             <label for="username" class="form-label">Username</label>
             <input type="text" class="form-control" id="username" name="username" required>
+            
             <label for="password" class="form-label">Password</label>
             <input type="password" class="form-control" id="password" name="password" required>
+            
             <div class="form-check mt-3">
                 <label class="form-check-label" for="useradmin">Are you an organizer?</label>
                 <input class="form-check-input" type="checkbox" id="useradmin" name="useradmin">
             </div>
+
+            <div id="organizer-options" style="display: none;" class="mt-3">
+                <label for="forclub" class="form-label">Club Name</label>
+                <input type="text" class="form-control" id="forclub" name="forclub">
+
+                <div class="form-check mt-2">
+                    <input class="form-check-input" type="checkbox" id="createclub" name="createclub">
+                    <label class="form-check-label" for="createclub">Create new club if name not found?</label>
+                </div>
+            </div>
+
         </div>
         <button type="submit" class="btn btn-primary">Register</button>
     </form>
 </div>
+
+<script>
+    const useradminCheckbox = document.getElementById('useradmin');
+    const organizerOptions = document.getElementById('organizer-options');
+
+    useradminCheckbox.addEventListener('change', () => {
+        organizerOptions.style.display = useradminCheckbox.checked ? 'block' : 'none';
+    });
+</script>


### PR DESCRIPTION
Added clubname and new club checkbox to register page, which now matches a user to a club if they spell it right, and creates a new one for them if they select the new club checkbox (and club doesnt already exist in table). Overrides previous organizer of club (for now). Most /render calls now pass session variable user to them (for future), and removed club description (no data)